### PR TITLE
Fix FileOpenError

### DIFF
--- a/arib/ass.py
+++ b/arib/ass.py
@@ -150,7 +150,7 @@ Last Style Storage: Default
 Video File: {title}
 
 
-'''.format(width=width, height=height, title=title)
+'''.format(width=width, height=height, title=unicode(title, 'utf-8'))
     self._f.write(header)
 
   def write_styles(self):


### PR DESCRIPTION
In fact the error here is not the FileOpenError, it's an UnicodeDecodeError, due to the filename contains Japanese which encoded in byte code. We need to ensure that the filename is encoded in unicode.