### PR TITLE
Fixes incomplete SRT output when `ts2srt` encounters parsing errors.

### DIFF
--- a/arib/ts2srt.py
+++ b/arib/ts2srt.py
@@ -144,7 +144,13 @@ class TS2srt:
         ts.OnTSPacket = self.on_ts_packet
         ts.OnESPacket = self.on_es_packet
 
-        ts.Parse()
+        try:
+            ts.Parse()
+        finally:
+            # Ensure buffered subtitle data is written to disk even if parsing
+            # encounters errors partway through the file
+            if self.srt:
+                self.srt.finalize()
 
         if self.pid < 0 and not self.cfg.quiet:
             print(f"*** Sorry. No ARIB subtitle content was found in file: {self.cfg.infile} ***")


### PR DESCRIPTION
When extracting subtitles from MPEG-TS files, if parsing encounters an error partway through the file, buffered SRT content is never written to disk. This results in incomplete subtitle files.